### PR TITLE
fix: aws credentials usage with rasterio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     package_data={"": ["LICENSE"]},
     include_package_data=True,
     install_requires=[
-        "eodag >= 2.3.1",
+        "eodag >= 2.3.2",
         "numpy",
         "rasterio",
         "protobuf",


### PR DESCRIPTION
Use AWS credentials from system or from eodag settings, and pass them to `rasterio.open()`.

- [x] Needs `eodag v2.3.2`
