### PR TITLE
fix: eodag version for binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,1 @@
-eodag[tutorials]
+eodag[tutorials] >= 2.3.3


### PR DESCRIPTION
Specify minimal eodag version for binder