### PR TITLE
feat: generic driver

### DIFF
--- a/eodag_cube/api/product/_product.py
+++ b/eodag_cube/api/product/_product.py
@@ -190,7 +190,7 @@ class EOProduct(EOProduct_core):
         :return: The rasterio environement variables
         :rtype: dict
         """
-        product_location_scheme = str(dataset_address).split("://")[0]
+        product_location_scheme = dataset_address.split("://")[0]
         if product_location_scheme == "s3" and hasattr(
             self.downloader, "get_bucket_name_and_prefix"
         ):

--- a/eodag_cube/api/product/drivers/__init__.py
+++ b/eodag_cube/api/product/drivers/__init__.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """EODAG drivers package"""
 from eodag.api.product.drivers.base import NoDriver  # noqa
+from eodag_cube.api.product.drivers.generic import GenericDriver
 from eodag_cube.api.product.drivers.sentinel2_l1c import Sentinel2L1C
 from eodag_cube.api.product.drivers.stac_assets import StacAssets
 
@@ -36,5 +37,9 @@ DRIVERS = [
             else False
         ],
         "driver": Sentinel2L1C(),
+    },
+    {
+        "criteria": [lambda prod: True],
+        "driver": GenericDriver(),
     },
 ]

--- a/eodag_cube/api/product/drivers/generic.py
+++ b/eodag_cube/api/product/drivers/generic.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021, CS GROUP - France, http://www.c-s.fr
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+import rasterio
+
+from eodag.api.product.drivers.base import DatasetDriver
+from eodag.utils import uri_to_path
+from eodag.utils.exceptions import AddressNotFound, UnsupportedDatasetAddressScheme
+
+
+class GenericDriver(DatasetDriver):
+    """Generic Driver for products that need to be downloaded"""
+
+    def get_data_address(self, eo_product, band):
+        """Get the address of a product subdataset.
+
+        See :func:`~eodag.api.product.drivers.base.DatasetDriver.get_data_address` to get help on the formal
+        parameters.
+        """
+        product_location_scheme = eo_product.location.split("://")[0]
+        if product_location_scheme == "file":
+
+            filenames = Path(uri_to_path(eo_product.location)).glob(f"**/*{band}*")
+
+            for filename in filenames:
+                try:
+                    # return the first file readable by rasterio
+                    rasterio.drivers.driver_from_extension(filename)
+                    return str(filename)
+                except ValueError:
+                    pass
+            raise AddressNotFound
+        raise UnsupportedDatasetAddressScheme(
+            "eo product {} is accessible through a location scheme that is not yet "
+            "supported by eodag: {}".format(eo_product, product_location_scheme)
+        )

--- a/tests/context.py
+++ b/tests/context.py
@@ -29,6 +29,7 @@ from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.api.product import EOProduct
 from eodag.api.product.drivers import DRIVERS
 from eodag.api.product.drivers.base import NoDriver
+from eodag_cube.api.product.drivers.generic import GenericDriver
 from eodag_cube.api.product.drivers.sentinel2_l1c import Sentinel2L1C
 from eodag_cube.api.product.drivers.stac_assets import StacAssets
 from eodag.api.search_result import SearchResult

--- a/tests/units/test_eoproduct_driver_generic.py
+++ b/tests/units/test_eoproduct_driver_generic.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021, CS GROUP - France, http://www.c-s.fr
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from contextlib import contextmanager
+
+from tests import TEST_RESOURCES_PATH, EODagTestCase
+from tests.context import (
+    AddressNotFound,
+    EOProduct,
+    GenericDriver,
+    UnsupportedDatasetAddressScheme,
+)
+
+
+class TestEOProductDriverGeneric(EODagTestCase):
+    def setUp(self):
+        super(TestEOProductDriverGeneric, self).setUp()
+        self.product = EOProduct(
+            self.provider, self.eoproduct_props, productType="FAKE_PRODUCT_TYPE"
+        )
+        self.product.properties["title"] = os.path.join(
+            TEST_RESOURCES_PATH,
+            "products",
+            "S2A_MSIL1C_20180101T105441_N0206_R051_T31TDH_20180101T124911.SAFE",
+        )
+        self.generic_driver = GenericDriver()
+
+    def test_driver_get_local_dataset_address_bad_band(self):
+        """Driver must raise AddressNotFound if non existent band is requested"""
+        with self._filesystem_product() as product:
+            driver = GenericDriver()
+            band = "B02"
+            self.assertRaises(AddressNotFound, driver.get_data_address, product, band)
+
+    def test_driver_get_local_dataset_address_ok(self):
+        """Driver returns a good address for an existing band"""
+        with self._filesystem_product() as product:
+            band = "B01"
+            address = self.generic_driver.get_data_address(product, band)
+            self.assertEqual(address, self.local_band_file)
+
+    def test_driver_get_http_remote_dataset_address_fail(self):
+        """Driver must raise UnsupportedDatasetAddressScheme if location scheme is http or https"""
+        # Default value of self.product.location is 'https://...'
+        band = "B01"
+        self.assertRaises(
+            UnsupportedDatasetAddressScheme,
+            self.generic_driver.get_data_address,
+            self.product,
+            band,
+        )
+
+    @contextmanager
+    def _filesystem_product(self):
+        original = self.product.location
+        try:
+            self.product.location = "file://{}".format(self.product.properties["title"])
+            yield self.product
+        finally:
+            self.product.location = original


### PR DESCRIPTION
Fixes #24 
If the product does not match any of the others drivers, this Generic driver will be used by default.
With this driver, running `eo_product.get_data(band=band)` will:
- download and extract the product
- search for files names containing `band` in the downloaded product directory
- return a xarray from the first found file readable by `rioxarray`