### PR TITLE
fix: check assets length for driver criteria

### DIFF
--- a/eodag_cube/api/product/drivers/__init__.py
+++ b/eodag_cube/api/product/drivers/__init__.py
@@ -23,7 +23,9 @@ from eodag_cube.api.product.drivers.stac_assets import StacAssets
 
 DRIVERS = [
     {
-        "criteria": [lambda prod: True if hasattr(prod, "assets") else False],
+        "criteria": [
+            lambda prod: True if len(getattr(prod, "assets", {})) > 0 else False
+        ],
         "driver": StacAssets(),
     },
     {


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/932, check assets length for driver choose criteria