### PR TITLE
feat: asset get_data

### DIFF
--- a/eodag_cube/api/product/_assets.py
+++ b/eodag_cube/api/product/_assets.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023, CS GROUP - France, https://www.csgroup.eu/
+#
+# This file is part of EODAG project
+#     https://www.github.com/CS-SI/EODAG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from eodag.api.product._assets import Asset as Asset_core
+from eodag.api.product._assets import AssetsDict as AssetsDict_core
+
+if TYPE_CHECKING:
+    from rasterio.enums import Resampling
+    from shapely.geometry.base import BaseGeometry
+    from xarray import DataArray
+
+
+class AssetsDict(AssetsDict_core):
+    """A UserDict object listing assets contained in a
+    :class:`~eodag.api.product._product.EOProduct` resulting from a search.
+
+    :param product: Product resulting from a search
+    :type product: :class:`~eodag.api.product._product.EOProduct`
+    :param args: (optional) Arguments used to init the dictionary
+    :type args: Any
+    :param kwargs: (optional) Additional named-arguments used to init the dictionary
+    :type kwargs: Any
+    """
+
+    def __setitem__(self, key: str, value: Dict[str, Any]) -> None:
+        super(AssetsDict_core, self).__setitem__(key, Asset(self.product, key, value))
+
+
+class Asset(Asset_core):
+    """A UserDict object containg one of the assets of a
+    :class:`~eodag.api.product._product.EOProduct` resulting from a search.
+
+    :param product: Product resulting from a search
+    :type product: :class:`~eodag.api.product._product.EOProduct`
+    :param key: asset key
+    :type key: str
+    :param args: (optional) Arguments used to init the dictionary
+    :type args: Any
+    :param kwargs: (optional) Additional named-arguments used to init the dictionary
+    :type kwargs: Any
+    """
+
+    def get_data(
+        self,
+        crs: Optional[str] = None,
+        resolution: Optional[float] = None,
+        extent: Optional[
+            Union[str, Dict[str, float], List[float], BaseGeometry]
+        ] = None,
+        resampling: Optional[Resampling] = None,
+        **rioxr_kwargs: Any,
+    ) -> DataArray:
+        """Retrieves asset raster data abstracted by the :class:`EOProduct`
+
+        :param crs: (optional) The coordinate reference system in which the dataset should be returned
+        :type crs: str
+        :param resolution: (optional) The resolution in which the dataset should be returned
+                            (given in the unit of the crs)
+        :type resolution: float
+        :param extent: (optional) The coordinates on which to zoom, matching the given CRS. Can be defined in
+                    different ways (its bounds will be used):
+
+                    * with a Shapely geometry object:
+                      :class:`shapely.geometry.base.BaseGeometry`
+                    * with a bounding box (dict with keys: "lonmin", "latmin", "lonmax", "latmax"):
+                      ``dict.fromkeys(["lonmin", "latmin", "lonmax", "latmax"])``
+                    * with a bounding box as list of float:
+                      ``[lonmin, latmin, lonmax, latmax]``
+                    * with a WKT str
+
+        :type extent: Union[str, dict, shapely.geometry.base.BaseGeometry]
+        :param resampling: (optional) Warp resampling algorithm passed to :class:`rasterio.vrt.WarpedVRT`
+        :type resampling: Resampling
+        :param rioxr_kwargs: kwargs passed to ``rioxarray.open_rasterio()``
+        :type rioxr_kwargs: Any
+        :returns: The numeric matrix corresponding to the sub dataset or an empty
+                    array if unable to get the data
+        :rtype: xarray.DataArray
+        """
+        return self.product.get_data(
+            band=self.key,
+            crs=crs,
+            resolution=resolution,
+            extent=extent,
+            resampling=resampling,
+            **rioxr_kwargs,
+        )

--- a/eodag_cube/api/product/_product.py
+++ b/eodag_cube/api/product/_product.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import numpy as np
 import rasterio
@@ -30,6 +30,7 @@ from rasterio.vrt import WarpedVRT
 from eodag.api.product._product import EOProduct as EOProduct_core
 from eodag.utils import get_geometry_from_various
 from eodag.utils.exceptions import DownloadError, UnsupportedDatasetAddressScheme
+from eodag_cube.api.product._assets import AssetsDict
 
 if TYPE_CHECKING:
     from rasterio.enums import Resampling
@@ -83,13 +84,18 @@ class EOProduct(EOProduct_core):
         super(EOProduct, self).__init__(
             provider=provider, properties=properties, **kwargs
         )
+        core_assets_data = self.assets.data
+        self.assets = AssetsDict(self)
+        self.assets.update(core_assets_data)
 
     def get_data(
         self,
         band: str,
         crs: Optional[str] = None,
         resolution: Optional[float] = None,
-        extent: Optional[Union[str, Dict[str, float], BaseGeometry]] = None,
+        extent: Optional[
+            Union[str, Dict[str, float], List[float], BaseGeometry]
+        ] = None,
         resampling: Optional[Resampling] = None,
         **rioxr_kwargs: Any,
     ) -> DataArray:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"], "eodag_cube": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "eodag >= 2.3.2",
+        "eodag @ git+https://github.com/CS-SI/eodag@develop",
         "numpy",
         "rasterio",
         "xarray",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"], "eodag_cube": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "eodag @ git+https://github.com/CS-SI/eodag@develop",
+        "eodag >= 2.12.0",
         "numpy",
         "rasterio",
         "xarray",

--- a/tests/units/test_eoproduct_driver_generic.py
+++ b/tests/units/test_eoproduct_driver_generic.py
@@ -39,7 +39,10 @@ class TestEOProductDriverGeneric(EODagTestCase):
             "products",
             "S2A_MSIL1C_20180101T105441_N0206_R051_T31TDH_20180101T124911.SAFE",
         )
-        self.generic_driver = GenericDriver()
+
+    def test_driver_set_stac_assets(self):
+        """The appropriate driver must have been set"""
+        self.assertIsInstance(self.product.driver, GenericDriver)
 
     def test_driver_get_local_dataset_address_bad_band(self):
         """Driver must raise AddressNotFound if non existent band is requested"""
@@ -52,7 +55,7 @@ class TestEOProductDriverGeneric(EODagTestCase):
         """Driver returns a good address for an existing band"""
         with self._filesystem_product() as product:
             band = "B01"
-            address = self.generic_driver.get_data_address(product, band)
+            address = self.product.driver.get_data_address(product, band)
             self.assertEqual(address, self.local_band_file)
 
     def test_driver_get_http_remote_dataset_address_fail(self):
@@ -61,7 +64,7 @@ class TestEOProductDriverGeneric(EODagTestCase):
         band = "B01"
         self.assertRaises(
             UnsupportedDatasetAddressScheme,
-            self.generic_driver.get_data_address,
+            self.product.driver.get_data_address,
             self.product,
             band,
         )

--- a/tests/units/test_eoproduct_driver_sentinel2_l1c.py
+++ b/tests/units/test_eoproduct_driver_sentinel2_l1c.py
@@ -42,7 +42,10 @@ class TestEOProductDriverSentinel2L1C(EODagTestCase):
             "products",
             "S2A_MSIL1C_20180101T105441_N0206_R051_T31TDH_20180101T124911.SAFE",
         )
-        self.sentinel2_l1c_driver = Sentinel2L1C()
+
+    def test_driver_set_stac_assets(self):
+        """The appropriate driver must have been set"""
+        self.assertIsInstance(self.product.driver, Sentinel2L1C)
 
     def test_driver_get_local_dataset_address_bad_band(self):
         """Driver must raise AddressNotFound if non existent band is requested"""
@@ -55,7 +58,7 @@ class TestEOProductDriverSentinel2L1C(EODagTestCase):
         """Driver returns a good address for an existing band"""
         with self._filesystem_product() as product:
             band = "B01"
-            address = self.sentinel2_l1c_driver.get_data_address(product, band)
+            address = self.product.driver.get_data_address(product, band)
             self.assertEqual(address, self.local_band_file)
 
     @mock_s3
@@ -64,7 +67,7 @@ class TestEOProductDriverSentinel2L1C(EODagTestCase):
         with self._remote_product_s3() as product:
             self.create_mock_s3_bucket_and_product()
             band = "B01"
-            address = self.sentinel2_l1c_driver.get_data_address(product, band)
+            address = self.product.driver.get_data_address(product, band)
             self.assertEqual(
                 address, "s3://sentinel-s2-l1c/tiles/31/T/DJ/2018/1/28/0/B01.jp2"
             )
@@ -75,7 +78,7 @@ class TestEOProductDriverSentinel2L1C(EODagTestCase):
         band = "B01"
         self.assertRaises(
             UnsupportedDatasetAddressScheme,
-            self.sentinel2_l1c_driver.get_data_address,
+            self.product.driver.get_data_address,
             self.product,
             band,
         )


### PR DESCRIPTION
Following https://github.com/CS-SI/eodag/pull/932 and the introduction of `AssetsDict` and `Asset` classes, adds the feature to use `get_data()` method directly on a given asset:

```py
data_array = eo_product.assets["B01"].get_data()
```

- [x] update eodag minimal version when a new version is released