### PR TITLE
fix: assets import

### DIFF
--- a/eodag_cube/api/product/__init__.py
+++ b/eodag_cube/api/product/__init__.py
@@ -16,4 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """EODAG product package"""
+from ._assets import Asset, AssetsDict  # noqa
 from ._product import EOProduct  # noqa


### PR DESCRIPTION
Following #46

Fixes `eodag-cube` assets import from external libs