### PR TITLE
fix: support zipped bands in s3

### DIFF
--- a/eodag_cube/api/product/_product.py
+++ b/eodag_cube/api/product/_product.py
@@ -222,7 +222,7 @@ class EOProduct(EOProduct_core):
         :rtype: Dict[str, Any]
         """
         product_location_scheme = dataset_address.split("://")[0]
-        if product_location_scheme == "s3" and hasattr(
+        if "s3" in product_location_scheme and hasattr(
             self.downloader, "get_product_bucket_name_and_prefix"
         ):
             bucket_name, prefix = self.downloader.get_product_bucket_name_and_prefix(

--- a/tests/units/test_eoproduct.py
+++ b/tests/units/test_eoproduct.py
@@ -219,3 +219,11 @@ class TestEOProduct(EODagTestCase):
         self.assertEqual(rio_env["AWS_HTTPS"], "YES")
         self.assertEqual(rio_env["AWS_S3_ENDPOINT"], "some.where")
         self.assertEqual(rio_env["AWS_VIRTUAL_HOSTING"], "FALSE")
+
+        # aws s3 with custom endpoint and band in zip
+        rio_env = product._get_rio_env("zip+s3://path/to/asset.zip!band.tiff")
+        self.assertEqual(len(rio_env), 4)
+        self.assertIsInstance(rio_env["session"], AWSSession)
+        self.assertEqual(rio_env["AWS_HTTPS"], "YES")
+        self.assertEqual(rio_env["AWS_S3_ENDPOINT"], "some.where")
+        self.assertEqual(rio_env["AWS_VIRTUAL_HOSTING"], "FALSE")


### PR DESCRIPTION
Fixes `_get_rio_env()` to support zipped bands in s3 storage