### PR TITLE
test: restore cfgrib for all python versions

### DIFF
--- a/tests/integration/test_eoproduct_xarray.py
+++ b/tests/integration/test_eoproduct_xarray.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 import os
-import sys
 from pathlib import Path
 
 import xarray as xr
@@ -50,17 +49,10 @@ class TestEOProductXarray(EODagTestCase):
         with product.to_xarray() as xarray_dict:
 
             self.assertIsInstance(xarray_dict, XarrayDict)
-            # cfgrib only available for python <= 3.9
-            if sys.version_info.minor <= 9:
-                self.assertEqual(len(xarray_dict), 3)
-            else:
-                self.assertEqual(len(xarray_dict), 2)
+            self.assertEqual(len(xarray_dict), 3)
+
             for key, value in xarray_dict.items():
-                # cfgrib only available for python <= 3.9
-                if sys.version_info.minor <= 9:
-                    self.assertIn(Path(key).suffix, {".nc", ".grib", ".jp2"})
-                else:
-                    self.assertIn(Path(key).suffix, {".nc", ".jp2"})
+                self.assertIn(Path(key).suffix, {".nc", ".grib", ".jp2"})
                 self.assertIsInstance(value, xr.Dataset)
                 # properties are a included in attrs
                 self.assertLessEqual(product.properties.items(), value.attrs.items())

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 import fsspec.implementations
@@ -158,10 +157,8 @@ class TestXarray(unittest.TestCase):
         file = OpenFile(fs, "https://foo/bar.nc")
         self.assertIn("h5netcdf", guess_engines(file))
 
-        # cfgrib only available for python <= 3.9
-        if sys.version_info.minor <= 9:
-            file = OpenFile(fs, "https://foo/bar.grib")
-            self.assertIn("cfgrib", guess_engines(file))
+        file = OpenFile(fs, "https://foo/bar.grib")
+        self.assertIn("cfgrib", guess_engines(file))
 
     @mock.patch(
         "eodag_cube.utils.xarray.guess_engines", return_value=["h5netcdf", "foo"]
@@ -189,9 +186,6 @@ class TestXarray(unittest.TestCase):
             ):
                 ds = try_open_dataset(file, foo="bar", baz="qux")
 
-    @unittest.skipIf(
-        sys.version_info.minor > 9, "cfgrib only available for python <= 3.9"
-    )
     @mock.patch("eodag_cube.utils.xarray.guess_engines", return_value=["cfgrib"])
     @mock.patch("eodag_cube.utils.xarray.fsspec.open")
     def test_try_open_dataset_remote_grib(self, mock_open, mock_guess_engines):
@@ -207,9 +201,6 @@ class TestXarray(unittest.TestCase):
         ):
             try_open_dataset(file, foo="bar", baz="qux")
 
-    @unittest.skipIf(
-        sys.version_info.minor > 9, "cfgrib only available for python <= 3.9"
-    )
     @mock.patch("eodag_cube.utils.xarray.guess_engines", return_value=["cfgrib"])
     @mock.patch("eodag_cube.utils.xarray.fsspec.open")
     def test_try_open_dataset_local_grib(self, mock_open, mock_guess_engines):


### PR DESCRIPTION
Restore `cfgrib` tests on all python versions as it is now usable on them