### PR TITLE
build: package name update

### DIFF
--- a/eodag_cube/__init__.py
+++ b/eodag_cube/__init__.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 """EODAG-cube: Data access for EODAG."""
 
-__title__ = "eodag-cube"
+__title__ = "eodag_cube"
 __description__ = "Data access for EODAG"
 __version__ = "0.6.0b1"
 __author__ = "CS GROUP - France"


### PR DESCRIPTION
To make sure `built` archive follows [PEP 625](https://peps.python.org/pep-0625/), project renamed from `eodag-cube` to `eodag_cube`