### PR TITLE
feat: EOProduct.rio_env method

### DIFF
--- a/eodag_cube/api/product/_assets.py
+++ b/eodag_cube/api/product/_assets.py
@@ -27,8 +27,11 @@ from eodag.api.product._assets import AssetsDict as AssetsDict_core
 from eodag.utils import DEFAULT_DOWNLOAD_TIMEOUT, DEFAULT_DOWNLOAD_WAIT, _deprecated
 
 if TYPE_CHECKING:
+    from contextlib import nullcontext
+
     from fsspec.core import OpenFile
     from rasterio.enums import Resampling
+    from rasterio.env import Env
     from shapely.geometry.base import BaseGeometry
     from xarray import DataArray
 
@@ -127,6 +130,13 @@ class Asset(Asset_core):
         :returns: asset data file object
         """
         return self.product.get_file_obj(self.key, wait, timeout)
+
+    def rio_env(self) -> Union[Env, nullcontext]:
+        """Get rasterio environment
+
+        :return: The rasterio environment
+        """
+        return self.product.rio_env(self.get("href"))
 
     def to_xarray(
         self,

--- a/eodag_cube/utils/xarray.py
+++ b/eodag_cube/utils/xarray.py
@@ -107,10 +107,16 @@ def try_open_dataset(file: OpenFile, **xarray_kwargs: dict[str, Any]) -> xr.Data
             if engine == "rasterio":
                 # prevents to read all file in memory since rasterio 1.4.0
                 # https://github.com/rasterio/rasterio/issues/3232
-                opener = file.fs.open if "s3" not in file.fs.protocol else None
+                opener = (
+                    file.fs.open
+                    if not any(p in file.fs.protocol for p in ["local", "s3"])
+                    else None
+                )
                 da = rioxarray.open_rasterio(
                     getattr(file, "full_name", file.path),
                     opener=opener,
+                    # default value from RasterioBackend
+                    mask_and_scale=True,
                     **xarray_kwargs,
                 )
                 ds = da.to_dataset(name="band_data")


### PR DESCRIPTION
`EOProduct.rio_env()` method for usage as context manager with `rasterio` engine