### PR TITLE
build: add python3.14 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,14 +33,14 @@ jobs:
 
         echo "Running benchmark on develop"
         git checkout --detach origin/develop
-        uvx --python 3.13 --with tox-uv tox -e benchmark -- --benchmark-json baseline.json
+        uvx --python 3.14 --with tox-uv tox -e benchmark -- --benchmark-json baseline.json
 
         echo "Running benchmark on current ref"
         git checkout --detach "${CURRENT_SHA}"
-        uvx --python 3.13 --with tox-uv tox -e benchmark -- --benchmark-json candidate.json
+        uvx --python 3.14 --with tox-uv tox -e benchmark -- --benchmark-json candidate.json
 
         echo "Comparing benchmark results"
-        uvx --python 3.13 \
+        uvx --python 3.14 \
           --with "pytest-benchmark @ git+https://github.com/ionelmc/pytest-benchmark.git@master" \
           pytest-benchmark compare --between=median \
           baseline.json candidate.json \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, "3.13"]
+        python-version: [3.9, "3.14"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: GIS"
 ]

--- a/tests/integration/test_eoproduct_xarray.py
+++ b/tests/integration/test_eoproduct_xarray.py
@@ -44,9 +44,14 @@ class TestEOProductXarray(EODagTestCase):
         )
         product.location = path_to_uri(products_path)
 
+        # cfgrib relies on eccodes which may not be available on all platforms;
+        # without it the .grib product cannot be opened
+        cfgrib_available = "cfgrib" in xr.backends.list_engines()
+        expected_len = 3 if cfgrib_available else 2
+
         with product.to_xarray() as xarray_dict:
             self.assertIsInstance(xarray_dict, XarrayDict)
-            self.assertEqual(len(xarray_dict), 3)
+            self.assertEqual(len(xarray_dict), expected_len)
 
             sorted_keys = sorted(xarray_dict.keys())
             # sort
@@ -66,7 +71,7 @@ class TestEOProductXarray(EODagTestCase):
         # check representations
         xd_repr = xarray_dict.__repr__()
         self.assertIsInstance(xd_repr, str)
-        self.assertTrue(xd_repr.startswith("<XarrayDict> (3)\n{"))
+        self.assertTrue(xd_repr.startswith(f"<XarrayDict> ({expected_len})\n{{"))
         self.assertTrue(xd_repr.endswith("}"))
         self.assertIn("Dataset", xd_repr)
         xd_repr_html = xarray_dict._repr_html_()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -157,8 +157,10 @@ class TestXarray(unittest.TestCase):
         file = OpenFile(fs, "https://foo/bar.nc")
         self.assertIn("h5netcdf", guess_engines(file))
 
-        file = OpenFile(fs, "https://foo/bar.grib")
-        self.assertIn("cfgrib", guess_engines(file))
+        # cfgrib relies on eccodes which may not be available on all platforms
+        if "cfgrib" in all_engines:
+            file = OpenFile(fs, "https://foo/bar.grib")
+            self.assertIn("cfgrib", guess_engines(file))
 
     @mock.patch("eodag_cube.utils.xarray.guess_engines", return_value=["h5netcdf", "foo"])
     @mock.patch("fsspec.open")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =  py39, py10, py311, py312, py313, pypi, linters
+envlist =  py39, py10, py311, py312, py313, py314, pypi, linters
 skipsdist = True
 
 # Mapping required by tox-gh-actions, only used in CI
@@ -10,6 +10,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 install_command = uv pip install --upgrade {opts} {packages}


### PR DESCRIPTION
Adds python3.14 support (now used in as max supported version in CI).

Adapt tests to `cfgrib` availability (does not install on windows + python 3.14)